### PR TITLE
Fix 'start' executable not found in %PATH%

### DIFF
--- a/open/exec_windows.go
+++ b/open/exec_windows.go
@@ -7,9 +7,9 @@ import (
 )
 
 func open(input string) *exec.Cmd {
-	return exec.Command("start", "", input)
+	return exec.Command("cmd", "/C", "start", "", input)
 }
 
 func openWith(input string, appName string) *exec.Cmd {
-	return exec.Command("start", "", appName, input)
+	return exec.Command("cmd", "/C", "start", "", appName, input)
 }


### PR DESCRIPTION
This fixes it in Windows 8.  Unable to test it in older versions however.
