### PR TITLE
Adjusted linux open-code to assume existence of xdg-open.

### DIFF
--- a/open/exec.go
+++ b/open/exec.go
@@ -4,15 +4,10 @@ package open
 
 import (
 	"os/exec"
-	"path"
-	"runtime"
 )
 
 func open(input string) *exec.Cmd {
-	// http://andrewbrookins.com/tech/golang-get-directory-of-the-current-file/
-	_, file, _, _ := runtime.Caller(1)
-	app := path.Join(path.Dir(file), "..", "vendor", "xdg-open")
-	return exec.Command(app, input)
+	return exec.Command("xdg-open", input)
 }
 
 func openWith(input string, appName string) *exec.Cmd {


### PR DESCRIPTION
The current implentation didn't work without a side-by-side file, which
somewhat reduces the usefulness of this library.

See https://github.com/skratchdot/open-golang/issues/2 .
