### PR TITLE
Switched to using rundll32 with FileProtocolHandler to avoid flashing shell window

### DIFF
--- a/open/exec_windows.go
+++ b/open/exec_windows.go
@@ -5,6 +5,8 @@ package open
 import (
 	"os/exec"
 	"strings"
+
+	"github.com/getlantern/runhide"
 )
 
 func cleaninput(input string) string {
@@ -13,9 +15,9 @@ func cleaninput(input string) string {
 }
 
 func open(input string) *exec.Cmd {
-	return exec.Command("cmd", "/C", "start", "", cleaninput(input))
+	return runhide.Command("cmd", "/C", "start", "", cleaninput(input))
 }
 
 func openWith(input string, appName string) *exec.Cmd {
-	return exec.Command("cmd", "/C", "start", "", appName, cleaninput(input))
+	return runhide.Command("cmd", "/C", "start", "", appName, cleaninput(input))
 }

--- a/open/exec_windows.go
+++ b/open/exec_windows.go
@@ -3,10 +3,15 @@
 package open
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+)
 
-	"github.com/getlantern/runhide"
+var (
+	cmd       = "url.dll,FileProtocolHandler"
+	runDll32  = filepath.Join(os.Getenv("SYSTEMROOT"), "System32", "rundll32.exe")
 )
 
 func cleaninput(input string) string {
@@ -15,9 +20,9 @@ func cleaninput(input string) string {
 }
 
 func open(input string) *exec.Cmd {
-	return runhide.Command("cmd", "/C", "start", "", cleaninput(input))
+	return exec.Command(runDll32, cmd, input)
 }
 
 func openWith(input string, appName string) *exec.Cmd {
-	return runhide.Command("cmd", "/C", "start", "", appName, cleaninput(input))
+	return exec.Command("cmd", "/C", "start", "", appName, cleaninput(input))
 }


### PR DESCRIPTION
...ning UI

When using open-golang in a Windows program compiled with the linker flag `-H=windowsgui`, every time that open-golang is used, a command window temporarily appears.

This uses rundll32 with FileProtocolHandler to avoid that.