### PR TITLE
Fixing #9 - not replacing ampersand in calls to rundll32

### DIFF
--- a/open/exec_windows.go
+++ b/open/exec_windows.go
@@ -20,7 +20,7 @@ func cleaninput(input string) string {
 }
 
 func open(input string) *exec.Cmd {
-	return exec.Command(runDll32, cmd, cleaninput(input))
+	return exec.Command(runDll32, cmd, input)
 }
 
 func openWith(input string, appName string) *exec.Cmd {


### PR DESCRIPTION
NOTE: The RunWith test fails on this branch, but fails on Master as well. I believe it's due to the fact that the function does not return an error when no handler exists.