### PR TITLE
Don't HideWindow, it breaks opening folders on windows

### DIFF
--- a/open/exec_windows.go
+++ b/open/exec_windows.go
@@ -22,7 +22,7 @@ func cleaninput(input string) string {
 
 func open(input string) *exec.Cmd {
 	cmd := exec.Command(runDll32, cmd, input)
-	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	//cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
 	return cmd
 }
 


### PR DESCRIPTION
This fixes a problem on windows where opening a folder with explorer doesn't work and no error is returned.