### PR TITLE
causing goplay installation failed.

### DIFF
--- a/open/exec_windows.go
+++ b/open/exec_windows.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
+	// "syscall"
 )
 
 var (


### PR DESCRIPTION
... > go get -v -u github.com/haya14busa/goplay/cmd/goplay
github.com/haya14busa/goplay (download)
github.com/skratchdot/open-golang (download)
github.com/skratchdot/open-golang/open
# github.com/skratchdot/open-golang/open
..\skratchdot\open-golang\open\exec_windows.go:10:2: imported and not used: "syscall"