### PR TITLE
open: StartWith() and RunWith() revert to default if appName is empty

### DIFF
--- a/open/open.go
+++ b/open/open.go
@@ -38,6 +38,9 @@ func Start(input string) error {
 	Wait for the open command to complete.
 */
 func RunWith(input string, appName string) error {
+	if len(appName) == 0 {
+		return Run(input)
+	}
 	return openWith(input, appName).Run()
 }
 
@@ -46,5 +49,8 @@ func RunWith(input string, appName string) error {
 	Don't wait for the open command to complete.
 */
 func StartWith(input string, appName string) error {
+	if len(appName) == 0 {
+		return Start(input)
+	}
 	return openWith(input, appName).Start()
 }

--- a/open/open_test.go
+++ b/open/open_test.go
@@ -37,8 +37,14 @@ func TestStart(t *testing.T) {
 func TestRunWith(t *testing.T) {
 	// shouldn't error
 	input := "https://google.com/"
+	err := RunWith(input, "")
+	if err != nil {
+		t.Errorf("open.RunWith(\"%s\", \"\") threw an error: %s", input, err)
+	}
+
+	// shouldn't error
 	app := "firefox"
-	err := RunWith(input, app)
+	err = RunWith(input, app)
 	if err != nil {
 		t.Errorf("open.RunWith(\"%s\", \"%s\") threw an error: %s", input, app, err)
 	}
@@ -54,8 +60,14 @@ func TestRunWith(t *testing.T) {
 func TestStartWith(t *testing.T) {
 	// shouldn't error
 	input := "https://google.com/"
+	err := StartWith(input, "")
+	if err != nil {
+		t.Errorf("open.StartWith(\"%s\", \"\") threw an error: %s", input, err)
+	}
+
+	// shouldn't error
 	app := "firefox"
-	err := StartWith(input, app)
+	err = StartWith(input, app)
 	if err != nil {
 		t.Errorf("open.StartWith(\"%s\", \"%s\") threw an error: %s", input, app, err)
 	}


### PR DESCRIPTION
This package is used in an app where we are considering allowing the user to override the default browser. Basically, I'm a Firefox user, but for Reasons :tm:, only Chrome works with the app.

This change treats `RunWith(url, "")` as `Run(url)`, or `StartWith(url, "")` as `Start(url)`. This way, the app will use the default browser by default unless the user overrides the setting. It also saves us from wrapping or implementing this `open` package ourselves.